### PR TITLE
Flathub fix for version listing

### DIFF
--- a/com.github.Flacon.appdata.xml
+++ b/com.github.Flacon.appdata.xml
@@ -39,7 +39,11 @@
   </screenshots>
 
   <releases>
-    <release version="6.0.0" date="2020-05-30"/>
+    <release version="6.0.0" date="2020-05-30">
+      <description>
+        <p>Latest version of Flacon on Flathub.</p>
+      </description>
+    </release>
     <release version="5.5.1" date="2019-09-28"/>
     <release version="5.5.0" date="2019-09-28"/>
     <release version="5.4.0" date="2019-09-26"/>

--- a/run
+++ b/run
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+clear
+flatpak-builder --repo=testing-repo --force-clean build-dir com.github.Flacon.yaml
+flatpak --user remote-add --if-not-exists --no-gpg-verify flacon-testing-repo testing-repo
+flatpak --user install flacon-testing-repo com.github.Flacon -y
+flatpak --user install flacon-testing-repo com.github.Flacon.Debug -y
+flatpak update -y
+


### PR DESCRIPTION
The website cannot cope with releases missing release notes.