### PR TITLE
Remove original X11 permissions

### DIFF
--- a/com.github.Flacon.yaml
+++ b/com.github.Flacon.yaml
@@ -10,7 +10,6 @@ rename-icon: flacon
 finish-args:
   - --socket=wayland
   - --socket=fallback-x11
-  - --socket=x11
   - --share=ipc
   - --device=dri
 


### PR DESCRIPTION
X11 Fallback should still allow users to run without Wayland