### PR TITLE
Add read and write permissions to the home directory.

### DIFF
--- a/com.github.Flacon.yaml
+++ b/com.github.Flacon.yaml
@@ -19,8 +19,7 @@ finish-args:
   # Required for input-output
   # Flacon uses some advanced file scanning techniques
   # not compatible with portals
-  - --filesystem=xdg-download
-  - --filesystem=xdg-music
+  - --filesystem=home
   - --env=TMPDIR=/var/tmp
 
 cleanup:


### PR DESCRIPTION
As you know, when a user selects a CUE file, the program searches for the corresponding audio file. The flatpak portal system does not allow this to be done. You added permissions for the xdg-music and xdg-download directories, but that's not enough. The user can store files not only in ~/Downloads and ~/Music. 

Let's give the read/write rights to the home directory. Rights on write are needed because the user can store music in a directory other than xdg-music.

This won't solve all the problems, sometimes users store files on external drives, but in most cases it will help.

Flacon issue #116 Flacon doesn't recognize the length of the last track https://github.com/flacon/flacon/issues/116