### PR TITLE
Close Flacon Issue #207: Flatpak version 11.2.0 can't find flac but c…

### DIFF
--- a/com.github.Flacon.yaml
+++ b/com.github.Flacon.yaml
@@ -192,3 +192,10 @@ modules:
           project-id: 8408
           url-template: https://github.com/flacon/flacon/archive/v$version.tar.gz
 
+  - name: flacon-progs
+    buildsystem: simple
+    build-commands:
+      - ln -s /usr/bin/flac /app/bin/flac
+      - ln -s /usr/bin/lame /app/bin/lame
+      - ln -s /usr/bin/wavpack /app/bin/wavpack
+      - ln -s /usr/bin/wvunpack /app/bin/wvunpack


### PR DESCRIPTION
I analyzed the package. Some of the programs, more precisely **flac,  lame,  wavpack and  wvunpack** inside FlatPak are installed not in /app/bin/ but in /usr/bin.

We can fix it by adding the following section to the manifest file:
```
  - name: flacon-progs
    buildsystem: simple
    build-commands:
      - ln -s /usr/bin/flac /app/bin/flac
      - ln -s /usr/bin/lame /app/bin/lame
      - ln -s /usr/bin/wavpack /app/bin/wavpack
      - ln -s /usr/bin/wvunpack /app/bin/wvunpack
```
@Eonfge 
Maybe my decision is crooked, and you will do better.
